### PR TITLE
Closes #17. Check for info keys for listed controls.

### DIFF
--- a/data/certifications/FISMA.yaml
+++ b/data/certifications/FISMA.yaml
@@ -4,5 +4,6 @@ standards:
     AC-2:
     AC-6:
     CM-2:
+    AU-19:
   PCI:
     Regulation-6:

--- a/exports/Pages/_config.yml
+++ b/exports/Pages/_config.yml
@@ -32,6 +32,9 @@ navigation:
   url: PCI/
 - children:
   - internal: true
+    text: 'AU-19 '
+    url: AU-19/
+  - internal: true
     text: AC-2 ACCOUNT MANAGEMENT
     url: AC-2/
   - internal: true

--- a/exports/certifications/FISMA.yaml
+++ b/exports/certifications/FISMA.yaml
@@ -83,6 +83,7 @@ standards:
           of users) which are necessary to accomplish assigned tasks in accordance
           with organizational missions and business functions.
         name: LEAST PRIVILEGE
+    AU-19: {}
     CM-2:
       justifications:
       - name: AlienVault

--- a/renderers/certifications_to_pages.py
+++ b/renderers/certifications_to_pages.py
@@ -3,6 +3,7 @@ site based on https://pages.18f.gov/guides-template/ """
 
 
 from yaml import dump, load
+import logging
 
 
 def load_yaml(filename):
@@ -40,8 +41,16 @@ def create_control_nav(control_key, control):
     """ Creates a dictionary for a child page following the config file format
     For more info about the _config.yml file visit :
     https://pages.18f.gov/guides-template/update-the-config-file/ """
+    if 'meta' in control:
+        control_name = control['meta']['name']
+    else:
+        control_name = ""
+        logging.warning(
+            "`%s` control is missing `%s` for control nav. Is control in 'data/standards/*.yaml'?",
+            control_key, 'name'
+        )
     return {
-        'text': control_key + " " + control['meta']['name'],
+        'text': control_key + " " + control_name,
         'url': control_key + '/',
         'internal': True,
     }
@@ -66,8 +75,16 @@ def create_front_matter(standard_key, control_key, control):
     """ Generate yaml front matter for pages text
     For more info about pages front matter visit -
     https://pages.18f.gov/guides-template/add-a-new-page/ """
+    if 'meta' in control:
+        control_name = control['meta']['name']
+    else:
+        control_name = ""
+        logging.warning(
+            "`%s` control is missing `%s` for front matter. Is control in 'data/standards/*.yaml'?",
+            control_key, 'name'
+        )
     text = '---\npermalink: /{0}/{1}/\n'.format(standard_key, control_key)
-    text += 'title: {0} - {1}\n'.format(control_key, control['meta']['name'])
+    text += 'title: {0} - {1}\n'.format(control_key, control_name)
     text += 'parent: {0} Documentation\n---\n'.format(standard_key)
     return text
 
@@ -139,6 +156,7 @@ def convert_certifications(certification_path, output_path):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     convert_certifications(
         certification_path="exports/certifications/FISMA.yaml",
         output_path="exports/Pages"


### PR DESCRIPTION
Modified `renderers/certifications_to_pages.py` to check if `meta` key existed for a control before trying to look up control name. Replaces missing name with zero length string and generates log error to standout out so pages will still be generated.

Unfortunately, this solution does result in missing pages for a control with no name. 